### PR TITLE
Fixed bad date in heading section

### DIFF
--- a/ortc.html
+++ b/ortc.html
@@ -7,7 +7,6 @@
           async class="remove"></script>
   <script class="remove">
 var respecConfig = {
-    "title": "Object RTC (ORTC) API for WebRTC",
     "specStatus": "CG-DRAFT",
     "shortName":  "orca-api",
     "editors": [


### PR DESCRIPTION
The date was showing as 1 Jan 1970. After inquiring I've made some changes that work for me with advice from @RobinBerjon, HTML spec editor.

http://htmlpreview.github.io/?https://raw.github.com/SteveALee/ortc/master/ortc.html

See commit comments for details
