### PR TITLE
Receiver.stop() does not cause receiver.track onended event

### DIFF
--- a/index.html
+++ b/index.html
@@ -3443,7 +3443,9 @@ interface RTCRtpReceiver : RTCStatsProvider {
               is final like <code><var>receiver</var>.track.stop()</code>.
               <code><var>receiver</var>.track.stop()</code> does
               not affect track clones and also does not stop <var>receiver</var>
-              so that Receiver Reports continue to be sent.</p>
+              so that Receiver Reports continue to be sent. Calling
+              <code><var>receiver</var>.track.stop()</code> does not cause
+              the "onended" event to fire for <code>track</code>.</p>
               <div>
                 <em>No parameters.</em>
               </div>

--- a/index.html
+++ b/index.html
@@ -3444,7 +3444,7 @@ interface RTCRtpReceiver : RTCStatsProvider {
               <code><var>receiver</var>.track.stop()</code> does
               not affect track clones and also does not stop <var>receiver</var>
               so that Receiver Reports continue to be sent. Calling
-              <code><var>receiver</var>.track.stop()</code> does not cause
+              <code><var>receiver</var>.stop()</code> does not cause
               the "onended" event to fire for <code>track</code>.</p>
               <div>
                 <em>No parameters.</em>


### PR DESCRIPTION
Fix for Issue https://github.com/w3c/ortc/issues/596

Related WebRTC Issue: https://github.com/w3c/webrtc-pc/issues/878