### PR TITLE
Effect of sender.track set to null

### DIFF
--- a/index.html
+++ b/index.html
@@ -2707,7 +2707,8 @@ interface RTCRtpSender : RTCStatsProvider {
               If <code>track</code> is ended, or if
               <code>track</code>.<var>muted</var> is set to <code>true</code>,
               the <code>RTCRtpSender</code> sends silence (audio) or a black
-              frame (video).</p>
+              frame (video). If <code>track</code> is set to null then
+              the <code><a>RTCRtpSender</a></code> does not send RTP.</p>
             </dd>
             <dt><dfn><code>transport</code></dfn> of type <span class=
             "idlAttrType"><a>RTCDtlsTransport</a></span>, readonly</dt>


### PR DESCRIPTION
Fix for Issue https://github.com/w3c/ortc/issues/616.

Related to WebRTC 1.0 PR https://github.com/w3c/webrtc-pc/pull/944