### PR TITLE
Reference to IETF RTCP Routing Rules

### DIFF
--- a/index.html
+++ b/index.html
@@ -8106,21 +8106,18 @@ function accept(signaller, remote) {
       <p>Since statistics are retrieved from objects within the ORTC API, and information
       within RTCP packets is used to maintain some of the statistics, the handling of
       RTCP packets is important to the operation of the statistics API.</p>
-      <p>RTCP packets arriving on an <code><a>RTCDtlsTransport</a></code> are decrypted
-      and a notification is sent to all <code><a>RTCRtpSender</a></code> and
-      <code><a>RTCRtpReceiver</a></code> objects utilizing that transport.
-      <code><a>RTCRtpSender</a></code> and <code><a>RTCRtpReceiver</a></code> objects
-      then examine the RTCP packets to determine the information relevant to their
-      operation and the statistics maintained by them.</p>
-      <p>RTCP packets should be queued for 30 seconds and all
+      <p>RTCP packets arriving on a <code><a>RTCDtlsTransport</a></code> are decrypted
+      and the algorithm described in [[!JSEP]] Appendix B is used to route the RTCP
+      packets to the appropriate <code><a>RTCRtpSender</a></code> and
+      <code><a>RTCRtpReceiver</a></code> objects.  The <code><a>RTCRtpSender</a></code> 
+      and <code><a>RTCRtpReceiver</a></code> objects then examine the RTCP packets to
+      determine the information relevant to their operation and the statistics maintained
+      by them.</p>
+      <p>RTCP packets should be queued for 30 seconds so that
       <code><a>RTCRtpSender</a></code> and <code><a>RTCRtpReceiver</a></code> objects on
       the related <code><a>RTCDTlsTransport</a></code> have access to those packets until
       the packet is removed from the queue, should the <code><a>RTCRtpSender</a></code>
       or <code><a>RTCRtpReceiver</a></code> objects need to examine them.</p>
-      <p>Relevant SSRC fields within selected RTCP packets are summarized within
-      [[!RFC3550]] Section 6.4.1 (Sender Report), Section 6.4.2 (Receiver Report),
-      Section 6.5 (SDES), Section 6.6 (BYE), [[!RFC4585]] Section 6.1 (Feedback
-      Messages), and [[!RFC3611]] Section 2 (Extended Reports).</p>
     </section>
     <section>
       <h4>Example</h4>


### PR DESCRIPTION
Work-in-progress (not suitable for merging). 

Awaits integration of RTCP routing rules into the MMUSIC BUNDLE draft.

Fix for Issue https://github.com/w3c/ortc/issues/643