### PR TITLE
Removing text talking about key shortening that was incorrect

### DIFF
--- a/index.html
+++ b/index.html
@@ -1099,21 +1099,11 @@ interface RTCIceGathererEvent : Event {
                 parameters.</p>
                 <p>However, this specification uses a simplified <a>alg</a>
                 approach. The length of the HMAC key
-                (<code>RTCOAuthCredential.macKey</code>) MAY be any multiple of
-                bytes greater than 20 (160 bits). When the <code><a>RTCIceGatherer</a></code>
-                computes the message integrity attributes it supports, it will
-                shorten the key to the length required by each algorithm,
-                according to [[!RFC7635]]. For example, a 256-bit key can be
-                used to compute both the HMAC-SHA-1 and HMAC-SHA-256 message
-                integrity attributes, shortening the key to 160 bits in the
-                case of HMAC-SHA-1. This negates the need to query the HMAC
+                (<code>RTCOAuthCredential.macKey</code>) MAY be any integer number of
+                bytes greater than 20 (160 bits). This negates the need to query the HMAC
                 Algorithm capabilities of the <code><a>RTCIceGatherer</a></code>,
                 and still allows for hash agility as described by [[STUN-BIS]],
                 Section 15.3.</p>
-                <div class="note">[[!RFC7635]] doesn't explicitly define
-                how keys are shortened; there is only a brief reference to this
-                in Appendix B. This needs to be adressed in the IETF TRAM
-                working group.</div>
                 <div class="note">According to [[!RFC7635]] Section 4.1, the
                 HMAC key MUST be a symmetric key.</div>
                 <p>Currently the STUN/TURN protocols use only SHA-1 and SHA-2


### PR DESCRIPTION
Fix for Issue https://github.com/w3c/ortc/issues/701

Equivalent WebRTC 1.0 PR: https://github.com/w3c/webrtc-pc/pull/1453