### PR TITLE
setTransport checking of transport.state

### DIFF
--- a/index.html
+++ b/index.html
@@ -3157,8 +3157,8 @@ interface RTCRtpSender : RTCStatsProvider {
                 </li>
                 <li>
                   <p>If <code>setTransport()</code> is called with no arguments,
-                  or if <var>withTransport</var> is unset, <a>throw</a> a
-                  <code>TypeError</code>.</p>
+                  or if <var>withTransport</var> is unset, <a>throw</a> an
+                  <code>InvalidParameters</code>.</p>
                 </li>
                 <li>
                   <p>If <code><var>withTransport</var>.transport.component</code> is

--- a/index.html
+++ b/index.html
@@ -3157,8 +3157,8 @@ interface RTCRtpSender : RTCStatsProvider {
                 </li>
                 <li>
                   <p>If <code>setTransport()</code> is called with no arguments,
-                  or if <var>withTransport</var> is unset, <a>throw</a> an
-                  <code>InvalidParameters</code>.</p>
+                  or if <var>withTransport</var> is unset, <a>throw</a> a
+                  <code>TypeError</code>.</p>
                 </li>
                 <li>
                   <p>If <code><var>withTransport</var>.transport.component</code> is
@@ -3172,12 +3172,14 @@ interface RTCRtpSender : RTCStatsProvider {
                 <li>
                   <p>If <code><var>withTransport</var></code> is set and
                   <code><var>withTransport</var>.state</code> is
-                  <code>closed</code>, <a>throw</a> an <code>InvalidStateError</code>.</p>
+                  <code>closed</code> or <code>failed</code>,
+                  <a>throw</a> an <code>InvalidStateError</code>.</p>
                 </li>
                 <li>
                   <p>If <code><var>withRtcpTransport</var></code> is set and
                   <code><var>withRtcpTransport</var>.state</code> is
-                  <code>closed</code>, <a>throw</a> an <code>InvalidStateError</code>.</p>
+                  <code>closed</code> or <code>failed</code>,
+                  <a>throw</a> an <code>InvalidStateError</code>.</p>
                 </li>
                 <li>
                   <p>Set <code>transport</code> to <var>withTransport</var> and
@@ -3746,8 +3748,8 @@ interface RTCRtpReceiver : RTCStatsProvider {
                 </li>
                 <li>
                   <p>If <code>setTransport()</code> is called with no arguments,
-                  or if <var>withTransport</var> is unset, <a>throw</a> an
-                  <code>InvalidParameters</code>.</p>
+                  or if <var>withTransport</var> is unset, <a>throw</a> a
+                  <code>TypeError</code>.</p>
                 </li>
                 <li>
                   <p>If <code><var>withTransport</var>.transport.component</code> is
@@ -3761,12 +3763,14 @@ interface RTCRtpReceiver : RTCStatsProvider {
                 <li>
                   <p>If <code><var>withTransport</var></code> is set and
                   <code><var>withTransport</var>.state</code> is
-                  <code>closed</code>, <a>throw</a> an <code>InvalidStateError</code>.</p>
+                  <code>closed</code> or <code>failed</code>,
+                  <a>throw</a> an <code>InvalidStateError</code>.</p>
                 </li>
                 <li>
                   <p>If <code><var>withRtcpTransport</var></code> is set and
                   <code><var>withRtcpTransport</var>.state</code> is
-                  <code>closed</code>, <a>throw</a> an <code>InvalidStateError</code>.</p>
+                  <code>closed</code> or <code>failed</code>,
+                  <a>throw</a> an <code>InvalidStateError</code>.</p>
                 </li>
                 <li>
                   <p>Replace <code>transport</code> with <var>withTransport</var> and

--- a/index.html
+++ b/index.html
@@ -3600,27 +3600,15 @@ interface RTCSsrcConflictEvent : Event {
     <section id="rtcrtpreceiver-operation*">
       <h3>Operation</h3>
       <p>A <code><a>RTCRtpReceiver</a></code> instance is constructed from a value of
-      <code>kind</code> and an <code><a>RTCDtlsTransport</a></code> object.
-      An <code><a>RTCRtpReceiver</a></code> object can be garbage-collected once
+      <code>kind</code> and an <code><a>RTCDtlsTransport</a></code> object. If an attempt
+      is made to construct an <code><a>RTCRtpReceiver</a></code> object with
+      <code>transport.state</code> or <code>rtcpTransport.state</code> with a value of
+      <code>closed</code>, <a>throw</a> an <code>InvalidStateError</code>. Upon
+      construction, <code>track</code> is set, and the value of <code>track.kind</code>
+      is determined based on the value of <var>kind</var> passed in the constructor.</p>
+      <p>An <code><a>RTCRtpReceiver</a></code> object can be garbage-collected once
       <code>stop()</code> is called and it is no longer referenced.</p>
-      <p>When an <code><a>RTCRtpReceiver</a></code> is constructed, the user agent
-      MUST run the following steps:</p>
-      <ol>
-        <li>Let <var>kind</var> be the first argument.</li>
-        <li>If <var>kind</var> does not represent a supported <code>kind</code>,
-        <a>throw</a> a <code>TypeError</code>.</li>
-        <li>Let <var>transport</var> be the second argument.</li>
-        <li>If <code><var>transport</var>.state</code> is <code>closed</code> or
-        <code>failed</code>, <a>throw</a> an <code>InvalidStateError</code>.</li>
-        <li>Let <var>rtcpTransport</var> be the third argument, if provided.</li>
-        <li>If <var>rtcpTransport</var> is set and
-        <code><var>rtcpTransport</var>.state</code> is <code>closed</code> or
-        <code>failed</code>, <a>throw</a> an <code>InvalidStateError</code>.</li>
-        <li>Let <var>receiver</var> be the <code><a>RTCRtpReceiver</a></code> object being constructed.</li>
-        <li>Let <var>receiver</var> have an <dfn>[[\Track]]</dfn> internal slot, initialized to a
-        <code>MediaStreakTrack</code>.</li>
-        <li>Set <code>[[\Track]].kind</code> to the value of <var>kind</var>.</li>
-      </ol>
+
     </section>
     <section id="rtcrtpreceiver-interface-definition*">
       <h3>Interface Definition</h3>

--- a/index.html
+++ b/index.html
@@ -2966,30 +2966,13 @@ function accept(mySignaller, remote) {
     </section>
     <section id="rtcrtpsender-operation*">
       <h3>Operation</h3>
-      <p>A <code><a>RTCRtpSender</a></code> instance is constructed from an
-      <a>MediaStreamTrack</a> object or <code>kind</code> and associated to an
-      <code><a>RTCDtlsTransport</a></code>. An <code><a>RTCRtpSender</a></code>
-      object can be garbage-collected once <code>stop()</code> is called and it
-      is no longer referenced.</p>
-      <p>When an <code><a>RTCRtpSender</a></code> is constructed, the user agent
-      MUST run the following steps:</p>
-      <ol>
-        <li>Let <var>trackOrKind</var> be the first argument.</li>
-        <li>If <var>trackOrKind</var> is of type <code>MediaStreamTrack</code>
-        and <code><var>trackOrKind</var>.readyState</code> is <code>ended</code>,
-        <a>throw</a> an <code>InvalidStateError</code>.</li>
-        <li>If <var>trackOrKind</var> is of type <code>DOMString</code>
-        and <var>trackOrKind</var> does not represent a supported <code>kind</code>,
-        <a>throw</a> a <code>TypeError</code>.</li>
-        <li>Let <var>transport</var> be the second argument, if provided.</li>
-        <li>If <var>transport</var> is set and
-        <code><var>transport</var>.state</code> is <code>closed</code> or
-        <code>failed</code>, <a>throw</a> an <code>InvalidStateError</code>.</li>
-        <li>Let <var>rtcpTransport</var> be the third argument, if provided.</li>
-        <li>If <var>rtcpTransport</var> is set and
-        <code><var>rtcpTransport</var>.state</code> is <code>closed</code> or
-        <code>failed</code>, <a>throw</a> an <code>InvalidStateError</code>.</li>
-      </ol>
+      <code><a>RTCDtlsTransport</a></code>. If an attempt is made to construct an
+      <code><a>RTCRtpSender</a></code> object with <code>transport.state</code> or
+      <code>rtcpTransport.state</code> <code>closed</code>, or if
+      <code>track.readyState</code> is <code>ended</code>, <a>throw</a> an
+      <code>InvalidStateError</code>.</p>
+      <p>An <code><a>RTCRtpSender</a></code> object can be garbage-collected once
+      <code>stop()</code> is called and it is no longer referenced.</p>
     </section>
     <section id="rtcrtpsender-interface-definition*">
       <h3>Interface Definition</h3>

--- a/index.html
+++ b/index.html
@@ -2968,13 +2968,28 @@ function accept(mySignaller, remote) {
       <h3>Operation</h3>
       <p>A <code><a>RTCRtpSender</a></code> instance is constructed from an
       <a>MediaStreamTrack</a> object or <code>kind</code> and associated to an
-      <code><a>RTCDtlsTransport</a></code>. If an attempt is made to construct an
-      <code><a>RTCRtpSender</a></code> object with <code>transport.state</code> or
-      <code>rtcpTransport.state</code> <code>closed</code>, or if
-      <code>track.readyState</code> is <code>ended</code>, <a>throw</a> an
-      <code>InvalidStateError</code>.</p>
-      <p>An <code><a>RTCRtpSender</a></code> object can be garbage-collected once
-      <code>stop()</code> is called and it is no longer referenced.</p>
+      <code><a>RTCDtlsTransport</a></code>. An <code><a>RTCRtpSender</a></code>
+      object can be garbage-collected once <code>stop()</code> is called and it
+      is no longer referenced.</p>
+      <p>When an <code><a>RTCRtpSender</a></code> is constructed, the user agent
+      MUST run the following steps:</p>
+      <ol>
+        <li>Let <var>trackOrKind</var> be the first argument.</li>
+        <li>If <var>trackOrKind</var> is of type <code>MediaStreamTrack</code>
+        and <code><var>trackOrKind</var>.readyState</code> is <code>ended</code>,
+        <a>throw</a> an <code>InvalidStateError</code>.</li>
+        <li>If <var>trackOrKind</var> is of type <code>DOMString</code>
+        and <var>trackOrKind</var> does not represent a supported <code>kind</code>,
+        <a>throw</a> a <code>TypeError</code>.</li>
+        <li>Let <var>transport</var> be the second argument, if provided.</li>
+        <li>If <var>transport</var> is set and
+        <code><var>transport</var>.state</code> is <code>closed</code> or
+        <code>failed</code>, <a>throw</a> an <code>InvalidStateError</code>.</li>
+        <li>Let <var>rtcpTransport</var> be the third argument, if provided.</li>
+        <li>If <var>rtcpTransport</var> is set and
+        <code><var>rtcpTransport</var>.state</code> is <code>closed</code> or
+        <code>failed</code>, <a>throw</a> an <code>InvalidStateError</code>.</li>
+      </ol>
     </section>
     <section id="rtcrtpsender-interface-definition*">
       <h3>Interface Definition</h3>
@@ -3600,14 +3615,27 @@ interface RTCSsrcConflictEvent : Event {
     <section id="rtcrtpreceiver-operation*">
       <h3>Operation</h3>
       <p>A <code><a>RTCRtpReceiver</a></code> instance is constructed from a value of
-      <code>kind</code> and an <code><a>RTCDtlsTransport</a></code> object. If an attempt
-      is made to construct an <code><a>RTCRtpReceiver</a></code> object with
-      <code>transport.state</code> or <code>rtcpTransport.state</code> with a value of
-      <code>closed</code>, <a>throw</a> an <code>InvalidStateError</code>. Upon
-      construction, <code>track</code> is set, and the value of <code>track.kind</code>
-      is determined based on the value of <var>kind</var> passed in the constructor.</p>
-      <p>An <code><a>RTCRtpReceiver</a></code> object can be garbage-collected once
+      <code>kind</code> and an <code><a>RTCDtlsTransport</a></code> object.
+      An <code><a>RTCRtpReceiver</a></code> object can be garbage-collected once
       <code>stop()</code> is called and it is no longer referenced.</p>
+      <p>When an <code><a>RTCRtpReceiver</a></code> is constructed, the user agent
+      MUST run the following steps:</p>
+      <ol>
+        <li>Let <var>kind</var> be the first argument.</li>
+        <li>If <var>kind</var> does not represent a supported <code>kind</code>,
+        <a>throw</a> a <code>TypeError</code>.</li>
+        <li>Let <var>transport</var> be the second argument.</li>
+        <li>If <code><var>transport</var>.state</code> is <code>closed</code> or
+        <code>failed</code>, <a>throw</a> an <code>InvalidStateError</code>.</li>
+        <li>Let <var>rtcpTransport</var> be the third argument, if provided.</li>
+        <li>If <var>rtcpTransport</var> is set and
+        <code><var>rtcpTransport</var>.state</code> is <code>closed</code> or
+        <code>failed</code>, <a>throw</a> an <code>InvalidStateError</code>.</li>
+        <li>Let <var>receiver</var> be the <code><a>RTCRtpReceiver</a></code> object being constructed.</li>
+        <li>Let <var>receiver</var> have an <dfn>[[\Track]]</dfn> internal slot, initialized to a
+        <code>MediaStreakTrack</code>.</li>
+        <li>Set <code>[[\Track]].kind</code> to the value of <var>kind</var>.</li>
+      </ol>
     </section>
     <section id="rtcrtpreceiver-interface-definition*">
       <h3>Interface Definition</h3>

--- a/index.html
+++ b/index.html
@@ -2966,6 +2966,8 @@ function accept(mySignaller, remote) {
     </section>
     <section id="rtcrtpsender-operation*">
       <h3>Operation</h3>
+      <p>A <code><a>RTCRtpSender</a></code> instance is constructed from an
+      <a>MediaStreamTrack</a> object or <code>kind</code> and associated to an
       <code><a>RTCDtlsTransport</a></code>. If an attempt is made to construct an
       <code><a>RTCRtpSender</a></code> object with <code>transport.state</code> or
       <code>rtcpTransport.state</code> <code>closed</code>, or if

--- a/index.html
+++ b/index.html
@@ -3748,8 +3748,8 @@ interface RTCRtpReceiver : RTCStatsProvider {
                 </li>
                 <li>
                   <p>If <code>setTransport()</code> is called with no arguments,
-                  or if <var>withTransport</var> is unset, <a>throw</a> a
-                  <code>TypeError</code>.</p>
+                  or if <var>withTransport</var> is unset, <a>throw</a> an
+                  <code>InvalidParameters</code>.</p>
                 </li>
                 <li>
                   <p>If <code><var>withTransport</var>.transport.component</code> is


### PR DESCRIPTION
Can't use an `RTCDtlsTransport` in the `failed` state in `setTransport`.