### PR TITLE
RTP routing: remove muxId limitation

### DIFF
--- a/index.html
+++ b/index.html
@@ -4677,7 +4677,6 @@ mySignaller.myOfferTracks({
       </ol>
       <p>payload type table:<p>
       <ol>
-      <li>If <code><var>parameters</var>.muxId</code> is set, abort these steps.</li>
       <li>If <code><var>parameters</var>.encodings[<var>i</var>].ssrc</code> is unset for all
       values of <var>i</var> from 0 to <code>encodings.length-1</code>, then add
       entries to <code>pt_table</code> by setting


### PR DESCRIPTION
Partial fix for https://github.com/w3c/ortc/issues/568

Removing muxId limitation on PT table filling since this limitation does not exist in BUNDLE Section 10.2, nor in any ORTC implementation.