### PR TITLE
QUIC: Add buffering support to write()

### DIFF
--- a/index.html
+++ b/index.html
@@ -9348,11 +9348,14 @@ function accept(mySignaller, remote) {
 interface RTCQuicStream {
     readonly        attribute RTCQuicTransport    transport;
     readonly        attribute RTCQuicStreamState  state;
+    readonly        attribute unsigned long       bufferedAmount;
+                    attribute unsigned long       bufferedAmountLowThreshold;
     void                  finish ();
     void                  reset ();
     void                  write (Uint8Array data);
     unsigned long         readInto (Uint8Array data);
                     attribute EventHandler        onstatechange;
+                    attribute EventHandler        onbufferedlowamount;
 };</pre>
         <section>
           <h2>Attributes</h2>
@@ -9378,6 +9381,45 @@ interface RTCQuicStream {
               <code><a>statechange</a></code>, <em class="rfc2119" title="MUST">MUST</em>
               be fired any time the <code><a>RTCQuicStreamState</a></code>
               changes.</p>
+            </dd>
+            <dt><code>bufferedAmount</code> of type <span class="idlAttrType"><a>unsigned
+            long</a></span>, readonly</dt>
+            <dd>
+              <p>The <dfn id="dom-quicstream-bufferedamount"><code>bufferedAmount</code></dfn>
+              attribute <em class="rfc2119" title="MUST">MUST</em> return the number of
+              bytes of application data that have been queued using <code>write</code>
+              but that, as of the last time the event loop started executing a task,
+              had not yet been transmitted to the network. This includes any data sent
+              during the execution of the current task, regardless of whether the
+              <a>user agent</a> is able to transmit text asynchronously with script
+              execution. This does not include framing overhead incurred by the
+              protocol, or buffering done by the operating system or network hardware.
+              If the <code><a>RTCQuicStream</a></code> is in the <code>closed</code>
+              state, this attribute's value will only increase with each call to the
+              <code>write</code> method (the attribute does not reset to zero once the
+              <code><a>RTCQuicStream</a></code> closes).</p>
+            </dd>
+            <dt><code>bufferedAmountLowThreshold</code> of type <span class=
+            "idlAttrType"><a>unsigned long</a></span></dt>
+            <dd>
+              <p>The <dfn id="dom-quicstream-bufferedamountlowthreshold"><code>
+              bufferedAmountLowThreshold</code></dfn> attribute sets the threshold at
+              which the <code><a href="#dom-quicstream-bufferedamount">
+              bufferedAmount</a></code> is considered to be low. When the <code><a href=
+              "#dom-quicstream-bufferedamount">bufferedAmount</a></code> decreases from
+              above this threshold to equal or below it, the <code title=
+              "event-quicstream-oncanwrite"><a href=
+              "#event-quicstream-oncanwrite">onbufferedlowamount</a></code> event
+              fires. The <code><a href=
+              "#dom-quicstream-bufferedamountlowthreshold">bufferedAmountLowThreshold</a></code>
+              is initially zero for each new <code><a>RTCQuicStream</a></code>, but the
+              application may change its value at any time.</p>
+            </dd>
+            <dt><dfn><code>onbufferedlowamount</code></dfn> of type <span class=
+            "idlAttrType"><a>EventHandler</a></span></dt>
+            <dd>
+              <p>The event type of this event handler is <code><a href=
+              "#event-quicstream-onbufferedlowamount">onbufferedlowamount</a></code>.</p>
             </dd>
           </dl>
        </section>
@@ -9441,14 +9483,17 @@ interface RTCQuicStream {
               <p>When the <code>write</code> method is called, the <a>user agent</a> MUST run the
               following steps:</p>
               <ol>
+               <li>Let <var>data</var> be the first argument.</li>
                <li>Let <var>stream</var> be the <code><a>RTCQuicStream</a></code>
-               object on which data is to be sent.</li>
+               object on which <var>data</var> is to be sent.</li>
                <li>If <var>stream</var>'s <a>[[\Writeable]]</a> slot is <code>false</code>,
                <a>throw</a> an <code>InvalidStateError</code> and abort these steps.</li>
-               <li>Let <var>data</var> be the data stored in the section of the
-               buffer described by the <code>Uint8Array</code> object.</li>
+               <li>Increase the <code><a>bufferedAmount</a></code> attribute by the
+               length of <var>data</var> in bytes.</li>
                <li>Queue <var>data</var> for transmission on <var>stream</var>'s
-               underlying data transport.
+               underlying data transport. If queuing <var>data</var> is not
+               possible because not enough buffer space is available, <a>throw</a>
+               an <code>OperationError</code>.
                <div class="note">The actual transmission of data occurs in
                parallel. If sending data leads to a QUIC-level error, the
                application will be notified asynchronously through the


### PR DESCRIPTION
This patch adds support for buffering to the RTCQuicStream.write method. The `bufferedAmount`, `bufferedAmountLowThreshold` and `onbufferedamountlow` attributes are utilized to enable building an `RTCDataChannel` interface on top of the `RTCQuicStream` abstraction.

@lgrahl @pthatcher Can you review/comment?