### PR TITLE
RTCQuicStream.waitForReadable() Incorrect threshold

### DIFF
--- a/index.html
+++ b/index.html
@@ -9831,7 +9831,7 @@ interface RTCQuicStream {
             </dd>
            <dt><dfn data-idl><code>waitForReadable</code></dfn></dt>
             <dd>
-              <p><code>waitForReadable</code> resolves the promise 
+              <p><code>waitForReadable</code> resolves the promise
               when the data queued in the read buffer increases above
               the amount provided as an argument. If <code>waitForReadable</code>
               is called multiple times, multiple promises could be resolved when
@@ -9852,10 +9852,8 @@ interface RTCQuicStream {
                 <li>If <var>amount</var> is larger than the value of
                 <var>stream</var>'s <a>[[\TargetReadBufferedAmount]]</a> slot,
                 <a>reject</a> <var>p</var> with a newly created <code>OperationError</code>.</li>
-                <li>Let <var>threshold</var> be the value of <var>stream</var>'s
-                <a>[[\TargetReadBufferedAmount]]</a> slot minus <var>amount</var>.</li>
-                <li>When <a>[[\ReadBufferedAmount]]</a> increases from below the value
-                of <var>threshold</var> to greater than or equal to it,
+                <li>When <a>[[\ReadBufferedAmount]]</a> increases from below the
+                value of <var>amount</var> to greater than or equal to it,
                 <a>resolve</a> <var>p</var> with <code>undefined</code>.</li>
               </ol>
               <table class="parameters">


### PR DESCRIPTION
Fix for Issue https://github.com/w3c/webrtc-quic/issues/6
Rebase of PR https://github.com/w3c/ortc/pull/842