### PR TITLE
Consolidate RTP/RTCP routing sections within RtpReceiver section

### DIFF
--- a/index.html
+++ b/index.html
@@ -113,12 +113,14 @@
       <code><a>RTCDataChannel</a></code> (<a href="#rtcdatachannel*">Section 11</a>),
       <code><a>RTCSctpTransport</a></code> (<a href="#sctp-transport*">Section 12</a>) and
       <code><a>RTCCertificate</a></code> (<a href="#certificate-api">Section 15</a>).
-      Since the <code>send</code> and <code>receive</code> methods are mandatory-to-implement, the
-      RTP dictionaries (<a href="#rtcrtpdictionaries*">Section 9</a>) that these methods depend on are also
+      Since the <code>send</code> and <code>receive</code> methods are
+      mandatory-to-implement, the RTP dictionaries
+      (<a href="#rtcrtpdictionaries*">Section 9</a>) that these methods depend on are also
       mandatory-to-implement.  Mandatory-to-implement statistics are described in
       <a href="#mandatory-to-implement-stats">Section 13.3</a>.</p>
       <p>Implementation of the following interfaces is optional:
-      <code><a>RTCIceTransportController</a></code> (<a href="#rtcicetransportcontroller*">Section 7</a>),
+      <code><a>RTCIceTransportController</a></code>
+      (<a href="#rtcicetransportcontroller*">Section 7</a>),
       <code><a>RTCRtpListener</a></code> (<a href="#rtcrtplistener*">Section 8</a>),
       <code><a>RTCQuicTransport</a></code>,  
       <code><a>RTCQuicStream</a></code> and
@@ -129,7 +131,8 @@
       <p>The <code><a href=
       "http://dev.w3.org/html5/spec/webappapis.html#eventhandler">EventHandler</a></code>
       interface, representing a callback used for event handlers, and the <a href=
-      "http://dev.w3.org/html5/spec/webappapis.html#errorevent"><code><dfn>ErrorEvent</dfn></code></a>
+      "http://dev.w3.org/html5/spec/webappapis.html#errorevent">
+      <code><dfn>ErrorEvent</dfn></code></a>
       interface are defined in [[!HTML5]].</p>
       <p>The concepts <dfn><a href=
       "http://dev.w3.org/html5/spec/webappapis.html#queue-a-task">queue a task</a></dfn>,
@@ -164,7 +167,8 @@
       Section 4.2.2 and the <dfn>RTCOauthCredential</dfn>
       dictionary is defined in [[!WEBRTC10]] Section 4.2.3.</p> 
       <p>The <dfn>RTCQuicTransport</dfn> interface is defined in [[WEBRTC-QUIC]] Section 4
-      and the <dfn>RTCQuicStream</dfn> interface is defined in [[WEBRTC-QUIC]] Section 5.</p>
+      and the <dfn>RTCQuicStream</dfn> interface is defined in [[WEBRTC-QUIC]]
+      Section 5.</p>
     </section>
     <section>
       <h3>Scope</h3>
@@ -254,14 +258,16 @@ interface RTCIceGatherer : RTCStatsProvider {
 };</pre>
         <section>
           <h2>Constructors</h2>
-      <p>To validate the <code>options</code> argument in the <code><a>RTCIceGatherer</a></code>
-      constructor, implementations MUST run the following steps:</p>
+      <p>To validate the <code>options</code> argument in the
+      <code><a>RTCIceGatherer</a></code> constructor, implementations MUST run
+      the following steps:</p>
       <ol>
          <li>
            <p>Let <var>options</var> be the argument passed in the constructor.</p>
          </li>
          <li>
-           <p>Let <var>servers</var> be the value of <code><var>options</var>.iceServers</code>.</p>
+           <p>Let <var>servers</var> be the value of
+           <code><var>options</var>.iceServers</code>.</p>
          </li>
          <li>
            <p>Let <var>validatedServers</var> be an empty list.</p>
@@ -580,8 +586,9 @@ interface RTCIceGatherer : RTCStatsProvider {
                 </pre>
       <div>
         <p>The <dfn><code>RTCIceGatherCandidate</code></dfn> provides either an
-        <code><a>RTCIceCandidate</a></code> or an <code><a>RTCIceCandidateComplete</a></code>
-        indication that candidate gathering is complete.</p>
+        <code><a>RTCIceCandidate</a></code> or an
+        <code><a>RTCIceCandidateComplete</a></code> indication that candidate gathering
+        is complete.</p>
         <pre class="idl">
 typedef (RTCIceCandidate or RTCIceCandidateComplete) RTCIceGatherCandidate;</pre>
         <div class="idlTypedefDesc"></div>
@@ -648,8 +655,8 @@ typedef (RTCIceCandidate or RTCIceCandidateComplete) RTCIceGatherCandidate;</pre
               candidate that these are derived from. For host candidates, the
               <code>relatedAddress</code> is unset.</p>
             </dd>
-            <dt><dfn data-idl><code>relatedPort</code></dfn> of type <span class="idlMemberType"><a>unsigned
-            short</a></span></dt>
+            <dt><dfn data-idl><code>relatedPort</code></dfn> of
+            type <span class="idlMemberType"><a>unsigned short</a></span></dt>
             <dd>
               <p>For candidates that are derived from others, such as relay or reflexive
               candidates, the <code>relatedPort</code> refers to the host
@@ -830,7 +837,8 @@ typedef (RTCIceCandidate or RTCIceCandidateComplete) RTCIceGatherCandidate;</pre
               <th colspan="2">Enumeration description</th>
             </tr>
             <tr>
-              <td><dfn data-idl><code id="idl-def-RTCIceGathererState.new">new</code></dfn></td>
+              <td><dfn data-idl>
+              <code id="idl-def-RTCIceGathererState.new">new</code></dfn></td>
               <td>
                 <p>The object has been created but <code>gather()</code> has not been
                 called.</p>
@@ -959,7 +967,8 @@ interface RTCIceGathererIceErrorEvent : Event {
             <dt><dfn data-idl><code>statusText</code></dfn> of type <span class=
             "idlAttrType"><a>USVString</a></span>, readonly</dt>
             <dd>
-              <p>The STUN reason text returned by the STUN or TURN server [[STUN-PARAMETERS]].</p>
+              <p>The STUN reason text returned by the STUN or TURN server
+              [[STUN-PARAMETERS]].</p>
               <p>If the server could not be reached, <code><a>statusText</a></code> will
               be set to an implementation-specific value providing details about the
               error.</p>
@@ -1015,12 +1024,13 @@ dictionary RTCIceGathererIceErrorEventInit : EventInit {
       <p>The <code>icecandidate</code> event of the <code><a>RTCIceGatherer</a></code>
       object uses the <code><a>RTCIceGathererEvent</a></code> interface.</p>
       <p>Firing an <code><a>RTCIceGathererEvent</a></code> event named <var>e</var> with
-      an <code><a>RTCIceGatherCandidate</a></code> <var>candidate</var> and URL <var>url</var>
-      means that an event with the name <var>e</var>, which does not bubble (except where
-      otherwise stated) and is not cancelable (except where otherwise stated), and which
-      uses the <code><a>RTCIceGathererEvent</a></code> interface with the
-      <code>candidate</code> attribute set to the new ICE candidate, <em class="rfc2119"
-      title="MUST">MUST</em> be created and dispatched at the given target.</p>
+      an <code><a>RTCIceGatherCandidate</a></code> <var>candidate</var> and
+      URL <var>url</var> means that an event with the name <var>e</var>, which does
+      not bubble (except where otherwise stated) and is not cancelable (except
+      where otherwise stated), and which uses the <code><a>RTCIceGathererEvent</a></code>
+      interface with the <code>candidate</code> attribute set to the new ICE candidate,
+      <em class="rfc2119" title="MUST">MUST</em> be created and dispatched at the given
+      target.</p>
       <div>
 <pre class="idl">
 [ Constructor (DOMString type, RTCIceGathererEventInit eventInitDict), Exposed=Window]
@@ -4139,6 +4149,141 @@ interface RTCRtpReceiver : RTCStatsProvider {
         </section>
       </div>
     </section>
+    <section id="rtpmatchingrules*">
+      <h3>RTP matching rules</h3>
+      <p>In ORTC, RTP packets are delivered to <code><a>RTCRtpReceiver</a></code>
+      objects by the <code><a>RTCRtpListener</a></code>. When the
+      <code><a>RTCRtpListener</a></code> receives an RTP packet over
+      an <code><a>RTCDtlsTransport</a></code>, it attempts to determine which
+      <code><a>RTCRtpReceiver</a></code> object to deliver the packet to, based on
+      the values of the SSRC and payload type fields in the RTP header, as well as
+      the value of the <a>MID</a> RTP header extension, if present. If the
+      <code><a>RTCRtpReceiver</a></code> object to deliver the RTP packet to
+      cannot be determined, the <code><a>unhandledrtp</a></code> event is fired.</p>
+      <p>[[!BUNDLE]] Section 10.2 describes the algorithm used in WebRTC for
+      routing of RTP streams received over a shared transport to an SDP m-line
+      (representing an <code><a>RTCRtpSender</a></code>/<code><a>RTCRtpReceiver</a></code> pair),
+      using three tables: the <code>ssrc_table</code>
+      which maps SSRC values to <code><a>RTCRtpReceiver</a></code> objects,
+      the <code>muxId_table</code> which maps values of the <a>MID</a> header extension
+      to <code><a>RTCRtpReceiver</a></code> objects and the <code>pt_table</code> which
+      maps payload type values to <code><a>RTCRtpReceiver</a></code> objects.</p>
+      <p>Table entries referencing the <code><a>RTCRtpReceiver</a></code> object
+      <code><var>receiver</var></code> are added when <code><var>receiver</var>.receive(<var>parameters</var>)</code>
+      is called. When <code><var>receiver</var>.receive(<var>parameters</var>)</code> is
+      called again, changes are made to table entries. When <code><var>receiver</var>.stop</code>
+      is called, all entries referencing <code><var>receiver</var></code> are removed.</p>
+      <p>When multiple <code><a>RTCRtpReceiver</a></code> or <code><a>RTCRtpSender</a></code>
+      objects share a <code><a>RTCDtlsTransport</a></code>, this implies that they also
+      share a single SSRC [[!RFC3550]] and header extension [[!RFC5285]] numbering space.
+      The restrictions arising from this are described in [[!BUNDLE]] Sections 10.1 and 10.1.1.</p>      
+      <section class="informative" id="rtppackethandling*">
+      <h4>ORTC routing tables</h4>
+      <p>Since ORTC does not utilize <code>RTCRtpTransceiver</code> objects, 
+      this section provides a (non-normative) example of how an
+      <code><a>RTCRtpListener</a></code> implementation can emulate the
+      behavior described in [[!BUNDLE]] Section 10.2.</p>
+      <p>When <code>receive</code> is called, to fill the routing tables and
+      <dfn>check for conflicts</dfn>, run the following steps:</p>
+      <ol>
+      <li><p>Let <var>receiver</var> be the <code><a>RTCRtpReceiver</a></code>
+      object on which the <code>receive</code> method was called.</p></li>
+      <li>Let <var>withParameters</var> be the first argument.</li>
+      <li>MuxId table:</li>
+       <ol>
+         <li><p>If <code><var>withParameters</var>.muxId</code> is set and
+         <code>muxId_table[<var>withParameters</var>.muxId]</code> is unset,
+         set <code>muxId_table[<var>withParameters</var>.muxId]</code> to
+         <var>receiver</var>.</p></li>
+         <li><p>If <code><var>withParameters</var>.muxId</code> is set and
+         <code>muxId_table[<var>withParameters</var>.muxId]</code> is set
+         to a value other than <var>receiver</var>, <a>reject</a>
+         <code>receive</code> with <code>InvalidParameters</code> and
+         abort these steps.</p></li>
+       </ol>  
+      <li>SSRC table:</li> 
+      <p>For values of <var>i</var> from 0 to <code>encodings.length-1</code>:</p>
+      <ol>
+        <li><p>If <code><var>withParameters</var>.encodings[<var>i</var>].ssrc</code> is set
+        and <code>ssrc_table[<var>withParameters</var>.encodings[<var>i</var>].ssrc]</code>
+        is unset, set <code>ssrc_table[<var>withParameters</var>.encodings[<var>i</var>].ssrc]</code>
+        to <var>receiver</var>.</p></li>
+        <li><p>If <code><var>withParameters</var>.encodings[<var>i</var>].ssrc</code> is set
+        and <code>ssrc_table[<var>withParameters</var>.encodings[<var>i</var>].ssrc]</code>
+        is set to a value other than <var>receiver</var>, <a>reject</a>
+        <code>receive</code> with <code>InvalidParameters</code> and abort these steps.</p></li>    
+        <li><p>If <code><var>withParameters</var>.encodings[<var>i</var>].rtx.ssrc</code> is set
+        and <code>ssrc_table[<var>withParameters</var>.encodings[<var>i</var>].rtx.ssrc]</code>
+        is unset, set <code>ssrc_table[<var>withParameters</var>.encodings[<var>i</var>].rtx.ssrc]</code>
+        to <var>receiver</var>.</p></li>
+        <li><p>If <code><var>withParameters</var>.encodings[<var>i</var>].rtx.ssrc</code> is set
+        and <code>ssrc_table[<var>withParameters</var>.encodings[<var>i</var>].rtx.ssrc]</code>
+        is set to a value other than <var>receiver</var>, <a>reject</a>
+        <code>receive</code> with <code>InvalidParameters</code> and abort these steps.</p></li>  
+        <li><p>If <code><var>withParameters</var>.encodings[<var>i</var>].fec.ssrc</code> is set
+        and <code>ssrc_table[<var>withParameters</var>.encodings[<var>i</var>].fec.ssrc]</code>
+        is unset, set <code>ssrc_table[<var>withParameters</var>.encodings[<var>i</var>].fec.ssrc]</code>
+        to <var>receiver</var>.</p></li>
+        <li><p>If <code><var>withParameters</var>.encodings[<var>i</var>].fec.ssrc</code> is set
+        and <code>ssrc_table[<var>withParameters</var>.encodings[<var>i</var>].fec.ssrc]</code>
+        is set to a value other than <var>receiver</var>, <a>reject</a>
+        <code>receive</code> with <code>InvalidParameters</code> and abort these steps.</p></li>  
+      </ol>      
+      <li>payload type table:</li>
+      <ol>
+        <p>If <code><var>withParameters</var>.encodings[<var>i</var>].ssrc</code> is unset for all
+        values of <var>i</var> from 0 to <code>encodings.length-1</code>, then
+        for values of <var>j</var> from 0 to <code>codecs.length-1</code>:</p>
+        <ol>
+          <li><p>If <code>pt_table[<var>withParameters</var>.codecs[<var>j</var>].payloadType]</code>
+          is unset, set <code>pt_table[<var>withParameters</var>.codecs[<var>j</var>].payloadType]</code>
+          to <var>receiver</var>.</p></li>
+          <li><p>If <code>pt_table[<var>withParameters</var>.codecs[<var>j</var>].payloadType]</code>
+          is set to a value other than <var>receiver</var>, <a>reject</a> <code>receive</code> with
+          <code>InvalidParameters</code> and abort these steps.</p></li>
+        </ol>
+      </ol>
+      </section>
+      <section id="rtppackethandling*">
+      <h4>RTP packet handling</h4>
+      <p>When an RTP packet arrives, the implementation determines the
+      <code><a>RTCRtpReceiver</a></code> <var>rtp_receiver</var> to send it to as
+      follows:</p>
+      <p>If <code>ssrc_table[<var>packet.ssrc</var>]</code> is set:</p>
+        <ol>
+          <li>Check whether the value of <var>packet.pt</var> is equal to one of the
+          values of <code><var>parameters</var>.codecs[<var>j</var>].payloadType</code>
+          for the <code><a>RTCRtpReceiver</a></code> object <var>rtp_receiver</var>,
+          where <var>j</var> varies from 0 to <code>codecs.length-1</code>.</li>
+          <li>If <var>packet.pt</var> does not match, fire the
+          <code><a>unhandledrtp</a></code> event and abort these steps.</li>
+          <li>Set <var>rtp_receiver</var> to <code>ssrc_table[<var>packet.ssrc</var>]</code>.</li>
+          <li>Route the packet to <var>rtp_receiver</var> and abort these steps.</li>
+        </ol>
+       <p>Else if <var>packet.muxId</var> is set:</p>
+        <ol>
+          <li>If <code>muxId_table[<var>packet.muxId</var>]</code> is unset, fire the
+          <code><a>unhandledrtp</a></code> event, and abort these steps.</li>
+          <li>Check whether the value of <var>packet.pt</var> is equal to one of the
+          values of <code><var>parameters</var>.codecs[<var>j</var>].payloadType</code>
+          for the <code><a>RTCRtpReceiver</a></code> object <var>rtp_receiver</var>,
+          where <var>j</var> varies from 0 to <code>codecs.length-1</code>.</li>
+          <li>If <var>packet.pt</var> does not match, fire the
+          <code><a>unhandledrtp</a></code> event and abort these steps.</li>
+          <li>Set <var>rtp_receiver</var> to <code>muxId_table[<var>packet.muxId</var>]</code>.</li>
+          <li>Set <code>ssrc_table[<var>packet.ssrc</var>]</code> to <var>rtp_receiver</var>.</li>
+          <li>Route the packet to <var>rtp_receiver</var> and abort these steps.</li>
+        </ol>
+        <p>Else if <code>pt_table[<var>packet.pt</var>]</code> is set:</p>
+         <ol>
+           <li>Set <var>rtp_receiver</var> to <code>pt_table[<var>packet.pt</var>]</code>.</li>
+           <li>Set <code>ssrc_table[<var>packet.ssrc</var>]</code> to <var>rtp_receiver</var>.</li>
+           <li>Route the packet to <var>rtp_receiver</var> and abort these steps.</li>
+         </ol>
+        <p>Else if no matches are found in the <code>ssrc_table</code>, <code>muxId_table</code>
+        or <code>pt_table</code>, fire the <code><a>unhandledrtp</a></code> event.</p>
+      </section>
+    </section>
     <section class="informative" id="rtcrtpreceiver-example*">
       <h3>Examples</h3>
       <pre class="example highlight">
@@ -4638,141 +4783,6 @@ mySignaller.myOfferTracks({
       <h3>Operation</h3>
       <p>An <code><a>RTCRtpListener</a></code> instance is constructed from an
       <code><a>RTCDtlsTransport</a></code> object.</p>
-    </section>
-    <section id="rtpmatchingrules*">
-      <h3>RTP matching rules</h3>
-      <p>In ORTC, RTP packets are delivered to <code><a>RTCRtpReceiver</a></code>
-      objects by the <code><a>RTCRtpListener</a></code>. When the
-      <code><a>RTCRtpListener</a></code> receives an RTP packet over
-      an <code><a>RTCDtlsTransport</a></code>, it attempts to determine which
-      <code><a>RTCRtpReceiver</a></code> object to deliver the packet to, based on
-      the values of the SSRC and payload type fields in the RTP header, as well as
-      the value of the <a>MID</a> RTP header extension, if present. If the
-      <code><a>RTCRtpReceiver</a></code> object to deliver the RTP packet to
-      cannot be determined, the <code><a>unhandledrtp</a></code> event is fired.</p>
-      <p>[[!BUNDLE]] Section 10.2 describes the algorithm used in WebRTC for
-      routing of RTP streams received over a shared transport to an SDP m-line
-      (representing an <code><a>RTCRtpSender</a></code>/<code><a>RTCRtpReceiver</a></code> pair),
-      using three tables: the <code>ssrc_table</code>
-      which maps SSRC values to <code><a>RTCRtpReceiver</a></code> objects,
-      the <code>muxId_table</code> which maps values of the <a>MID</a> header extension
-      to <code><a>RTCRtpReceiver</a></code> objects and the <code>pt_table</code> which
-      maps payload type values to <code><a>RTCRtpReceiver</a></code> objects.</p>
-      <p>Table entries referencing the <code><a>RTCRtpReceiver</a></code> object
-      <code><var>receiver</var></code> are added when <code><var>receiver</var>.receive(<var>parameters</var>)</code>
-      is called. When <code><var>receiver</var>.receive(<var>parameters</var>)</code> is
-      called again, changes are made to table entries. When <code><var>receiver</var>.stop</code>
-      is called, all entries referencing <code><var>receiver</var></code> are removed.</p>
-      <p>When multiple <code><a>RTCRtpReceiver</a></code> or <code><a>RTCRtpSender</a></code>
-      objects share a <code><a>RTCDtlsTransport</a></code>, this implies that they also
-      share a single SSRC [[!RFC3550]] and header extension [[!RFC5285]] numbering space.
-      The restrictions arising from this are described in [[!BUNDLE]] Sections 10.1 and 10.1.1.</p>      
-      <section class="informative" id="rtppackethandling*">
-      <h4>ORTC routing tables</h4>
-      <p>Since ORTC does not utilize <code>RTCRtpTransceiver</code> objects, 
-      this section provides a (non-normative) example of how an
-      <code><a>RTCRtpListener</a></code> implementation can emulate the
-      behavior described in [[!BUNDLE]] Section 10.2.</p>
-      <p>When <code>receive</code> is called, to fill the routing tables and
-      <dfn>check for conflicts</dfn>, run the following steps:</p>
-      <ol>
-      <li><p>Let <var>receiver</var> be the <code><a>RTCRtpReceiver</a></code>
-      object on which the <code>receive</code> method was called.</p></li>
-      <li>Let <var>withParameters</var> be the first argument.</li>
-      <li>MuxId table:</li>
-       <ol>
-         <li><p>If <code><var>withParameters</var>.muxId</code> is set and
-         <code>muxId_table[<var>withParameters</var>.muxId]</code> is unset,
-         set <code>muxId_table[<var>withParameters</var>.muxId]</code> to
-         <var>receiver</var>.</p></li>
-         <li><p>If <code><var>withParameters</var>.muxId</code> is set and
-         <code>muxId_table[<var>withParameters</var>.muxId]</code> is set
-         to a value other than <var>receiver</var>, <a>reject</a>
-         <code>receive</code> with <code>InvalidParameters</code> and
-         abort these steps.</p></li>
-       </ol>  
-      <li>SSRC table:</li> 
-      <p>For values of <var>i</var> from 0 to <code>encodings.length-1</code>:</p>
-      <ol>
-        <li><p>If <code><var>withParameters</var>.encodings[<var>i</var>].ssrc</code> is set
-        and <code>ssrc_table[<var>withParameters</var>.encodings[<var>i</var>].ssrc]</code>
-        is unset, set <code>ssrc_table[<var>withParameters</var>.encodings[<var>i</var>].ssrc]</code>
-        to <var>receiver</var>.</p></li>
-        <li><p>If <code><var>withParameters</var>.encodings[<var>i</var>].ssrc</code> is set
-        and <code>ssrc_table[<var>withParameters</var>.encodings[<var>i</var>].ssrc]</code>
-        is set to a value other than <var>receiver</var>, <a>reject</a>
-        <code>receive</code> with <code>InvalidParameters</code> and abort these steps.</p></li>    
-        <li><p>If <code><var>withParameters</var>.encodings[<var>i</var>].rtx.ssrc</code> is set
-        and <code>ssrc_table[<var>withParameters</var>.encodings[<var>i</var>].rtx.ssrc]</code>
-        is unset, set <code>ssrc_table[<var>withParameters</var>.encodings[<var>i</var>].rtx.ssrc]</code>
-        to <var>receiver</var>.</p></li>
-        <li><p>If <code><var>withParameters</var>.encodings[<var>i</var>].rtx.ssrc</code> is set
-        and <code>ssrc_table[<var>withParameters</var>.encodings[<var>i</var>].rtx.ssrc]</code>
-        is set to a value other than <var>receiver</var>, <a>reject</a>
-        <code>receive</code> with <code>InvalidParameters</code> and abort these steps.</p></li>  
-        <li><p>If <code><var>withParameters</var>.encodings[<var>i</var>].fec.ssrc</code> is set
-        and <code>ssrc_table[<var>withParameters</var>.encodings[<var>i</var>].fec.ssrc]</code>
-        is unset, set <code>ssrc_table[<var>withParameters</var>.encodings[<var>i</var>].fec.ssrc]</code>
-        to <var>receiver</var>.</p></li>
-        <li><p>If <code><var>withParameters</var>.encodings[<var>i</var>].fec.ssrc</code> is set
-        and <code>ssrc_table[<var>withParameters</var>.encodings[<var>i</var>].fec.ssrc]</code>
-        is set to a value other than <var>receiver</var>, <a>reject</a>
-        <code>receive</code> with <code>InvalidParameters</code> and abort these steps.</p></li>  
-      </ol>      
-      <li>payload type table:</li>
-      <ol>
-        <p>If <code><var>withParameters</var>.encodings[<var>i</var>].ssrc</code> is unset for all
-        values of <var>i</var> from 0 to <code>encodings.length-1</code>, then
-        for values of <var>j</var> from 0 to <code>codecs.length-1</code>:</p>
-        <ol>
-          <li><p>If <code>pt_table[<var>withParameters</var>.codecs[<var>j</var>].payloadType]</code>
-          is unset, set <code>pt_table[<var>withParameters</var>.codecs[<var>j</var>].payloadType]</code>
-          to <var>receiver</var>.</p></li>
-          <li><p>If <code>pt_table[<var>withParameters</var>.codecs[<var>j</var>].payloadType]</code>
-          is set to a value other than <var>receiver</var>, <a>reject</a> <code>receive</code> with
-          <code>InvalidParameters</code> and abort these steps.</p></li>
-        </ol>
-      </ol>
-      </section>
-      <section id="rtppackethandling*">
-      <h4>RTP packet handling</h4>
-      <p>When an RTP packet arrives, the implementation determines the
-      <code><a>RTCRtpReceiver</a></code> <var>rtp_receiver</var> to send it to as
-      follows:</p>
-      <p>If <code>ssrc_table[<var>packet.ssrc</var>]</code> is set:</p>
-        <ol>
-          <li>Check whether the value of <var>packet.pt</var> is equal to one of the
-          values of <code><var>parameters</var>.codecs[<var>j</var>].payloadType</code>
-          for the <code><a>RTCRtpReceiver</a></code> object <var>rtp_receiver</var>,
-          where <var>j</var> varies from 0 to <code>codecs.length-1</code>.</li>
-          <li>If <var>packet.pt</var> does not match, fire the
-          <code><a>unhandledrtp</a></code> event and abort these steps.</li>
-          <li>Set <var>rtp_receiver</var> to <code>ssrc_table[<var>packet.ssrc</var>]</code>.</li>
-          <li>Route the packet to <var>rtp_receiver</var> and abort these steps.</li>
-        </ol>
-       <p>Else if <var>packet.muxId</var> is set:</p>
-        <ol>
-          <li>If <code>muxId_table[<var>packet.muxId</var>]</code> is unset, fire the
-          <code><a>unhandledrtp</a></code> event, and abort these steps.</li>
-          <li>Check whether the value of <var>packet.pt</var> is equal to one of the
-          values of <code><var>parameters</var>.codecs[<var>j</var>].payloadType</code>
-          for the <code><a>RTCRtpReceiver</a></code> object <var>rtp_receiver</var>,
-          where <var>j</var> varies from 0 to <code>codecs.length-1</code>.</li>
-          <li>If <var>packet.pt</var> does not match, fire the
-          <code><a>unhandledrtp</a></code> event and abort these steps.</li>
-          <li>Set <var>rtp_receiver</var> to <code>muxId_table[<var>packet.muxId</var>]</code>.</li>
-          <li>Set <code>ssrc_table[<var>packet.ssrc</var>]</code> to <var>rtp_receiver</var>.</li>
-          <li>Route the packet to <var>rtp_receiver</var> and abort these steps.</li>
-        </ol>
-        <p>Else if <code>pt_table[<var>packet.pt</var>]</code> is set:</p>
-         <ol>
-           <li>Set <var>rtp_receiver</var> to <code>pt_table[<var>packet.pt</var>]</code>.</li>
-           <li>Set <code>ssrc_table[<var>packet.ssrc</var>]</code> to <var>rtp_receiver</var>.</li>
-           <li>Route the packet to <var>rtp_receiver</var> and abort these steps.</li>
-         </ol>
-        <p>Else if no matches are found in the <code>ssrc_table</code>, <code>muxId_table</code>
-        or <code>pt_table</code>, fire the <code><a>unhandledrtp</a></code> event.</p>
-      </section>
     </section>
     <section id="rtcrtplistener-interface-definition*">
       <h3>Interface Definition</h3>
@@ -7638,7 +7648,8 @@ interface RTCDataChannel : EventTarget {
         <li><p>Let <var>channel</var> have an <dfn>[[\Ordered]]</dfn> internal
         slot initialized to <var>parameters</var>' <code>ordered</code> member.</p></li>
         <li><p>Let <var>channel</var> have a <dfn>[[\DataChannelProtocol]]</dfn>
-        internal slot initialized to <var>parameters</var>' <code>protocol</code> member.</p></li>
+        internal slot initialized to <var>parameters</var>' <code>protocol</code>
+        member.</p></li>
         <li><p>If <a>[[\DataChannelProtocol]]</a> is longer than 65535 bytes long,
         <a>throw</a> a <code>TypeError</code>.</p></li>
         <li><p>Let <var>channel</var> have a <dfn>[[\Negotiated]]</dfn> internal slot

--- a/index.html
+++ b/index.html
@@ -2765,12 +2765,12 @@ function initiate(mySignaller) {
         transport.addRemoteCandidate(remote.candidate);
       }
     }  };
-  // ... construct RtpSender/RtpReceiver objects as illustrated in Section 6.5 Example 9.
+  // ... construct RtpSender/RtpReceiver objects as illustrated in Section 6.6 Examples 8 and 9.
 
   mySignaller.mySendInitiate({
     ice: iceGatherer.getLocalParameters(),
     dtls: dtlsParameters,
-    // ... marshall RtpSender/RtpReceiver capabilities as illustrated in Section 6.5 Example 9.
+    // ... marshall RtpSender/RtpReceiver capabilities as illustrated in Section 6.6 Examples 8 and 9.
   }, function(remote) {
     // Create the ICE and DTLS transports
     var iceTransport = new RTCIceTransport(iceGatherer);
@@ -2782,7 +2782,7 @@ function initiate(mySignaller) {
     dtlsTransport.start(remote.dtls);
     dtlsTransports.push(dtlsTransport);
 
-    // ... configure RtpSender/RtpReceiver objects as illustrated in Section 6.5 Example 9.
+    // ... configure RtpSender/RtpReceiver objects as illustrated in Section 6.6 Examples 8 and 9.
   });
 }
                 </pre>
@@ -2830,12 +2830,12 @@ function accept(mySignaller, remote) {
   mySignaller.onRemoteCandidate = function(remote) {
     ice.addRemoteCandidate(remote.candidate);
   };
-  // ... create RtpSender/RtpReceiver objects as illustrated in Section 6.5 Example 9.
+  // ... create RtpSender/RtpReceiver objects as illustrated in Section 6.6 Examples 8 and 9.
 
   mySignaller.mySendAccept({
     ice: iceGatherer.getLocalParameters(),
     dtls: dtls.getLocalParameters()
-    // ... marshall RtpSender/RtpReceiver capabilities as illustrated in Section 6.5 Example 9.
+    // ... marshall RtpSender/RtpReceiver capabilities as illustrated in Section 6.6 Examples 8 and 9.
   });
 
   // Start the ICE transport with an implicit gather policy of "all"
@@ -2844,7 +2844,7 @@ function accept(mySignaller, remote) {
   // Start the DTLS transport
   dtls.start(remote.dtls);
 
-  // ... configure RtpSender/RtpReceiver objects as illustrated in Section 6.5 Example 9.
+  // ... configure RtpSender/RtpReceiver objects as illustrated in Section 6.6 Examples 8 and 9.
 }
                 </pre>
     </section>
@@ -3935,7 +3935,7 @@ interface RTCRtpReceiver : RTCStatsProvider {
                 </li>
                 <li><a>Complete validation checks</a> on <var>withParameters</var>.</li>
                 <li>
-                  <p>As described in Section 8.3.1, fill the <code>ssrc_table</code>,
+                  <p>As described in Section 6.5.1, fill the <code>ssrc_table</code>,
                    <code>muxId_table</code> and <code>pt_table</code> entries and
                    <a>check for conflicts</a>. If conflicts are found,
                    <a>reject</a> <var>p</var> and abort these steps.</p>
@@ -4282,6 +4282,24 @@ interface RTCRtpReceiver : RTCStatsProvider {
          </ol>
         <p>Else if no matches are found in the <code>ssrc_table</code>, <code>muxId_table</code>
         or <code>pt_table</code>, fire the <code><a>unhandledrtp</a></code> event.</p>
+      </section>
+      <section id="rtcpmatchingrules*">
+        <h3>RTCP matching rules</h3>
+        <p>RTCP packets arriving on a <code><a>RTCDtlsTransport</a></code> are decrypted
+        and the algorithm described in [[!BUNDLE]] Section 10.2 is used to route the RTCP
+        packets to the appropriate <code><a>RTCRtpSender</a></code> and
+        <code><a>RTCRtpReceiver</a></code> objects.  The <code><a>RTCRtpSender</a></code>
+        and <code><a>RTCRtpReceiver</a></code> objects then examine the RTCP packets to
+        determine the information relevant to their operation and the statistics maintained
+        by them.</p>
+        <p>RTCP packets should be queued for 30 seconds so that
+        <code><a>RTCRtpSender</a></code> and <code><a>RTCRtpReceiver</a></code> objects on
+        the related <code><a>RTCDTlsTransport</a></code> have access to those packets until
+        the packet is removed from the queue, should the <code><a>RTCRtpSender</a></code>
+        or <code><a>RTCRtpReceiver</a></code> objects need to examine them.</p>
+        <p>Since statistics are retrieved from objects within the ORTC API, and information
+        within RTCP packets is used to maintain some of the statistics, the handling of
+        RTCP packets is important to the operation of the <a href="#statistics-api">Statistics API</a>.</p>
       </section>
     </section>
     <section class="informative" id="rtcrtpreceiver-example*">
@@ -5606,7 +5624,7 @@ interface RTCRtpUnhandledEvent : Event {
               attributes (e.g. <code>fec</code>, <code>rtx</code>, <code>priority</code>,
               <code>maxBitrate</code>, <code>resolutionScale</code>, etc.) unset. When
               unset in a call to <code>receive()</code>, the behavior is described in
-              Section 8.3.</p>
+              Section 6.5.</p>
             </dd>
             <dt><dfn data-idl><code>degradationPreference</code></dfn> of type <span class=
             "idlMemberType"><a>RTCDegradationPreference</a></span></dt>
@@ -5636,7 +5654,7 @@ interface RTCRtpUnhandledEvent : Event {
               <p>The "encodings" or "layers" to be used for things like simulcast,
               Scalable Video Coding, RTX, FEC, etc.  When unset in a call to
               <code>receive()</code>, the behavior is described in
-              Section 8.3.</p>
+              Section 6.5.</p>
             </dd>
           </dl>
         </section>
@@ -8759,7 +8777,7 @@ function initiate(mySignaller) {
     dtls: dtls.getLocalParameters(),
     sctpCapabilities: RTCSctpTransport.getCapabilities(),
     port: sctp.port,
-    // ... marshall RtpSender/RtpReceiver capabilities as illustrated in Section 6.5 Example 9.
+    // ... marshall RtpSender/RtpReceiver capabilities as illustrated in Section 6.6 Examples 8 and 9.
   }, function(remote) {
     // Start the ICE, DTLS and SCTP transports
     ice.start(iceGatherer, remote.ice, RTCIceRole.controlling);
@@ -8768,7 +8786,7 @@ function initiate(mySignaller) {
     // Create the data channel object
     var channel = new RTCDataChannel(sctp, parameters);
     channel.send("foo");
-    // ... configure RtpSender/RtpReceiver objects as illustrated in Section 6.5 Example 9.
+    // ... configure RtpSender/RtpReceiver objects as illustrated in Section 6.6 Examples 8 and 9.
   });
 }
 </pre>
@@ -8826,7 +8844,7 @@ function accept(mySignaller, remote) {
     dtls: dtls.getLocalParameters(),
     sctpCapabilities: RTCSctpTransport.getCapabilities(),
     port: sctp.port,
-    // ... marshall RtpSender/RtpReceiver capabilities as illustrated in Section 6.5 Example 9.
+    // ... marshall RtpSender/RtpReceiver capabilities as illustrated in Section 6.6 Examples 8 and 9.
   });
 
    // Start the ICE, DTLS and SCTP transports
@@ -8835,7 +8853,7 @@ function accept(mySignaller, remote) {
   // Start the SctpTransport
   sctp.start(remote.sctpCapabilities, remote.port);
 
-  // ... configure RtpSender/RtpReceiver objects as illustrated in Section 6.5 Example 9.
+  // ... configure RtpSender/RtpReceiver objects as illustrated in Section 6.6 Examples 8 and 9.
 
   // Assume in-band signalling. We could also have sent
   // RTCDataChannelParameters in signalling and constructed
@@ -9113,24 +9131,6 @@ interface RTCStatsReport {
       other statistic defined in [[!WEBRTC-STATS]], and MAY generate
       statistics that are not documented.</p>
     </section>      
-    <section id="rtcpmatchingrules*">
-      <h3>RTCP matching rules</h3>
-      <p>Since statistics are retrieved from objects within the ORTC API, and information
-      within RTCP packets is used to maintain some of the statistics, the handling of
-      RTCP packets is important to the operation of the statistics API.</p>
-      <p>RTCP packets arriving on a <code><a>RTCDtlsTransport</a></code> are decrypted
-      and the algorithm described in [[!BUNDLE]] Section 10.2 is used to route the RTCP
-      packets to the appropriate <code><a>RTCRtpSender</a></code> and
-      <code><a>RTCRtpReceiver</a></code> objects.  The <code><a>RTCRtpSender</a></code>
-      and <code><a>RTCRtpReceiver</a></code> objects then examine the RTCP packets to
-      determine the information relevant to their operation and the statistics maintained
-      by them.</p>
-      <p>RTCP packets should be queued for 30 seconds so that
-      <code><a>RTCRtpSender</a></code> and <code><a>RTCRtpReceiver</a></code> objects on
-      the related <code><a>RTCDTlsTransport</a></code> have access to those packets until
-      the packet is removed from the queue, should the <code><a>RTCRtpSender</a></code>
-      or <code><a>RTCRtpReceiver</a></code> objects need to examine them.</p>
-    </section>
     <section class="informative">
       <h4>Example</h4>
       <p>Consider the case where the user is experiencing bad sound and the application
@@ -10721,13 +10721,13 @@ function initiate(mySignaller) {
     ice: iceGatherer.getLocalParameters(),
     dlts: dtls.getLocalParameters(),
     quic: quic.getLocalParameters(),
-    // ... marshall RtpSender/RtpReceiver capabilities as illustrated in Section 6.5 Example 9.
+    // ... marshall RtpSender/RtpReceiver capabilities as illustrated in Section 6.6 Examples 8 and 9.
   }, function(remote) {
     // Start the IceTransport, DtlsTransport and QuicTransport
     ice.start(iceGatherer, remote.ice, RTCIceRole.controlling);
     dtls.start(remote.dtls);
     quic.start(remote.quic);
-    // ... configure RtpSender/RtpReceiver objects as illustrated in Section 6.5 Example 9.
+    // ... configure RtpSender/RtpReceiver objects as illustrated in Section 6.6 Examples 8 and 9.
   });
 }
 </pre>
@@ -10784,7 +10784,7 @@ function accept(mySignaller, remote) {
     ice: iceGatherer.getLocalParameters(),
     dtls: dtls.getLocalParameters(),
     quic: quic.getLocalParameters(),
-    // ... marshall RtpSender/RtpReceiver capabilities as illustrated in Section 6.5 Example 9.
+    // ... marshall RtpSender/RtpReceiver capabilities as illustrated in Section 6.6 Examples 8 and 9.
   });
 
    // Start the IceTransport and DtlsTransport
@@ -10793,7 +10793,7 @@ function accept(mySignaller, remote) {
   // Start the QuicTransport
   quic.start(remote.quic);
 
-  // ... configure RtpSender/RtpReceiver objects as illustrated in Section 6.5 Example 9.
+  // ... configure RtpSender/RtpReceiver objects as illustrated in Section 6.6 Examples 8 and 9.
 
 }
                 </pre>
@@ -10806,8 +10806,8 @@ function accept(mySignaller, remote) {
       This section provides an example of what such a library
       function might do.</p>
       <pre class="example highlight">
-RTCRtpCapabilities function getCommonCapabilities(RTCRtpCapabilities localCapabilities,
-   RTCRtpCapabilities remoteCapabilities) {
+RTCRtpCapabilities function getCommonCapabilities(RTCRtpCapabilities 
+   localCapabilities, RTCRtpCapabilities remoteCapabilities) {
 // Function returning the common capabilities, based on the local sender and
 // remote receiver capabilities. An implementation is available here:
 // https://webrtc.github.io/adapter/adapter-latest.js
@@ -11061,7 +11061,7 @@ RTCRtpReceiveParameters function myCapsToRecvParams(RTCRtpCapabilities recvCaps,
     <section id="since-02-December-2016*">
       <h3>Changes since 02 December 2016</h3>
       <ol>
-        <li>Updated the RTP matching rules (Section 8.3) to address issues
+        <li>Updated the RTP matching rules (Section 6.5) to address issues
         <a href="https://github.com/w3c/ortc/issues/368">Issue 368</a> and
         <a href="https://github.com/w3c/ortc/issues/547">Issue 547</a>.
         </li>
@@ -11098,7 +11098,7 @@ RTCRtpReceiveParameters function myCapsToRecvParams(RTCRtpCapabilities recvCaps,
         <li>Added optional H.264 codec settings, as noted in:
         <a href="https://github.com/w3c/ortc/issues/641">Issue 641</a>
         </li>
-        <li>Updated Section 13.3 to refer to RTCP packet routing specification, as noted in:
+        <li>Updated Section 6.5.3 to refer to RTCP packet routing specification, as noted in:
         <a href="https://github.com/w3c/ortc/issues/643">Issue 643</a>
         </li>
         <li>Updated Examples 21 and 22 to reflect updated <code><a>RTCSctpTransport</a></code> API, as noted in:
@@ -11475,7 +11475,7 @@ RTCRtpReceiveParameters function myCapsToRecvParams(RTCRtpCapabilities recvCaps,
         <li>Clarified behavior of <var>resolutionScale</var>, as noted in: <a href=
         "https://github.com/w3c/ortc/issues/362">Issue 362</a>
         </li>
-        <li>Updated RTP matching rules in Section 8.3 to support FEC/RTX/RED, as noted
+        <li>Updated RTP matching rules in Section 6.5 to support FEC/RTX/RED, as noted
         in: <a href="https://github.com/w3c/ortc/issues/368">Issue 368</a>
         </li>
         <li>Clarified certificate checking behavior, as noted in: <a href=
@@ -11699,7 +11699,7 @@ RTCRtpReceiveParameters function myCapsToRecvParams(RTCRtpCapabilities recvCaps,
     <section id="since-22-January-2015*">
       <h3>Changes since 22 January 2015</h3>
       <ol>
-        <li>Updated Section 8.3 on RTP matching rules, as noted in: <a href=
+        <li>Updated Section 6.5 on RTP matching rules, as noted in: <a href=
         "https://github.com/w3c/ortc/issues/48">Issue 48</a>
         </li>
         <li>Further updates to the Statistics API, reflecting: <a href=
@@ -11714,7 +11714,7 @@ RTCRtpReceiveParameters function myCapsToRecvParams(RTCRtpCapabilities recvCaps,
         <li>Clarified pre-requisites for <code>insertDTMF()</code>, based on: <a href=
         "https://github.com/w3c/ortc/issues/178">Issue 178</a>
         </li>
-        <li>Added Section 13.4 and updated Section 9.5.1 to clarify aspects of RTCP
+        <li>Added Section 6.5.3 and updated Section 9.5.1 to clarify aspects of RTCP
         sending and receiving, based on: <a href=
         "https://github.com/w3c/ortc/issues/180">Issue 180</a>
         </li>

--- a/respec-config.js
+++ b/respec-config.js
@@ -1,7 +1,7 @@
 var respecConfig = {
   specStatus: "CG-DRAFT",
   shortName: "ortc-api",
-  publishDate: "2018-06-11",
+  publishDate: "2018-06-25",
   edDraftURI: "https://w3c.github.io/ortc/",
   editors: [
     {


### PR DESCRIPTION
Currently information on RTP matching is contained within the RtpListener section (optional to implement), and information on RTCP matching is in the Statistics API section. This PR consolidates this material within the RtpReceiver section. Since RTP/RTCP matching is necessary for the basic operation of ORTC, consolidating it makes it easier to find, and also hopefully clarifies the status of this material (e.g. routing of RTP and RTCP packets is not optional!). 